### PR TITLE
feat(ui): add portfolio 404 page

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/node": "^24.0.0",
     "@vercel/analytics": "^1.3.1",
     "astro": "^7.0.3",
+    "slot-text": "^0.3.1",
     "svelte": "^5.41.4",
     "tailwindcss": "^4.3.1",
     "tailwindcss-animated": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       astro:
         specifier: ^7.0.3
         version: 7.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(@vercel/functions@3.7.3)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0)
+      slot-text:
+        specifier: ^0.3.1
+        version: 0.3.1(svelte@5.56.4)
       svelte:
         specifier: ^5.41.4
         version: 5.56.4
@@ -2399,6 +2402,23 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  slot-text@0.3.1:
+    resolution: {integrity: sha512-gDHfMnFrz4CxqD7H8F3CqWVGYwTbgjpJiIH1bQg1Tj60TzgnLe47vuQDHNeyg4zbhsEAPFvUp05nG7lKsboCVw==}
+    peerDependencies:
+      react: '>=18 <20'
+      solid-js: '>=1.8 <2'
+      svelte: '>=4 <6'
+      vue: '>=3.4 <4'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
   smol-toml@1.7.0:
     resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
@@ -5182,6 +5202,10 @@ snapshots:
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
+
+  slot-text@0.3.1(svelte@5.56.4):
+    optionalDependencies:
+      svelte: 5.56.4
 
   smol-toml@1.7.0: {}
 

--- a/src/components/CardWork.astro
+++ b/src/components/CardWork.astro
@@ -56,6 +56,22 @@ const sortedWorks = data.works.sort((a, b) => {
 							<div />
 						</h3>
 						<p class="mt-2 text-sm leading-normal">{work.description}</p>
+						{work.timeline && (
+							<ol class="mt-4 grid gap-3 border-l border-slate-700/70 pl-4 sm:grid-cols-2 sm:border-l-0 sm:pl-0">
+								{work.timeline.map((step) => (
+									<li class="relative sm:border-l sm:border-slate-700/70 sm:pl-4">
+										<span class="absolute -left-[21px] top-1.5 h-2.5 w-2.5 rounded-full bg-teal-300 ring-4 ring-slate-900 sm:-left-[5px]" />
+										<p class="text-xs font-semibold uppercase tracking-wide text-teal-300">
+											{step.from} → {step.to}
+										</p>
+										<p class="mt-1 text-sm font-medium text-slate-200">{step.role}</p>
+										<p class="mt-1 text-sm leading-normal text-slate-400">
+											{step.description}
+										</p>
+									</li>
+								))}
+							</ol>
+						)}
 						<TechList tech={work.tech} />
 					</div>
 				</div>

--- a/src/components/Description.astro
+++ b/src/components/Description.astro
@@ -14,9 +14,9 @@
 	</div>
 	<div>
 		<p class="mb-4">
-			Actualmente, me desempeño como <span class="font-semibold text-slate-200">Cloud Engineer</span> en <a
+			Actualmente, me desempeño como <span class="font-semibold text-slate-200">Cloud Architect</span> en <a
 				class="font-medium text-slate-200 hover:text-teal-300 focus-visible:text-teal-300"
-				href="https://epamneoris.com"
+				href="https://www.epam.com/"
 				target="_blank"
 				rel="noreferrer noopener"
 				aria-label="EPAM (opens in a new tab)">EPAM</a

--- a/src/components/header/PersonalImage.astro
+++ b/src/components/header/PersonalImage.astro
@@ -7,13 +7,18 @@ import { Image } from "astro:assets";
 		<div
 			class="relative h-full w-full rounded-xl transition-all ease-in-out duration-700 [transform-style:preserve-3d] group-hover:[transform:rotateY(180deg)]"
 		>
-			<Image alt="Foto de perfil de Santiago Gaona Carvajal" src="/images/personal.webp" class="rounded-xl object-cover" width="240"
-						height="256"/>
+			<Image
+				alt="Foto de perfil de Santiago Gaona Carvajal"
+				src="/images/personal.webp"
+				class="rounded-xl object-cover"
+				width="240"
+				height="256"
+			/>
 			<div
 				class="absolute inset-0 h-full w-full rounded-xl bg-black/80 px-8 text-center text-white [transform:rotateY(180deg)] [backface-visibility:hidden]"
 			>
 				<div class="flex min-h-full flex-col items-center justify-center">
-					<p class="text-md font-medium">25 años</p>
+					<p class="text-md font-medium">26 años</p>
 					<p class="text-sm">Bucaramanga, Santander.</p>
 				</div>
 			</div>

--- a/src/data.json
+++ b/src/data.json
@@ -1,6 +1,6 @@
 {
   "name": "Santiago Gaona",
-  "position": "Ingeniero de Sistemas e Informática",
+  "position": "Ingeniero de Sistemas e Informática · Máster en Ingeniería de Software y Sistemas Informáticos",
   "minimal-description": "Diseño soluciones FullStack escalables, enfocadas en CI/CD y cloud",
   "works": [
     {
@@ -95,11 +95,25 @@
     },
     {
       "company": "EPAM Neoris",
-      "href": "https://epamneoris.com",
-      "position": "Cloud Engineer",
+      "href": "https://www.epam.com/",
+      "position": "Cloud Architect",
       "from": "2024-10",
       "to": "Presente",
-      "description": "Parte del equipo de arquitectura e infraestructura cloud para el sector bancario regional, implementando soluciones multinube en AWS y Azure. Enfocado en automatización de infraestructura, desarrollo de pipelines y módulos para cloud, y gestión de gobernanza, políticas de seguridad y alertas. Experiencia en IaC, CI/CD y optimización de recursos cloud.",
+      "description": "Parte del equipo de arquitectura e infraestructura cloud para el sector bancario regional, implementando soluciones multinube en AWS y Azure. Enfocado en diseño de arquitectura, gobierno cloud, seguridad, automatización de infraestructura, pipelines y optimización de recursos.",
+      "timeline": [
+        {
+          "from": "Oct 2024",
+          "to": "Ago 2025",
+          "role": "Cloud Engineer",
+          "description": "Automatización de infraestructura, CI/CD, módulos cloud y operación segura en entornos AWS y Azure."
+        },
+        {
+          "from": "Sep 2025",
+          "to": "Presente",
+          "role": "Cloud Architect",
+          "description": "Diseño de arquitectura cloud, gobierno, seguridad y evolución de soluciones multinube para banca regional."
+        }
+      ],
       "tech": [
         "AWS",
         "Terraform (IaC)",
@@ -109,6 +123,7 @@
         "CI/CD",
         "CloudFormation",
         "QuickSight",
+        "IA / Agents",
         "DevOps",
         "Azure"
       ]

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,7 +13,7 @@ const { title } = Astro.props;
 		<meta charset="UTF-8" />
 		<meta
 			name="description"
-			content="Ingeniero de Sistemas e Informática especializado en arquitectura e infraestructura. Experiencia en AWS, Azure, IaC y DevOps."
+			content="Ingeniero de Sistemas e Informática y Máster en Ingeniería de Software y Sistemas Informáticos, especializado en arquitectura e infraestructura. Experiencia en AWS, Azure, IaC y DevOps."
 		/>
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,54 @@
+---
+import Layout from "../layouts/Layout.astro";
+import "slot-text/style.css";
+---
+
+<Layout title="Página no encontrada — Santiago Gaona Carvajal">
+	<section class="flex min-h-screen items-center justify-center px-6 py-24">
+		<div class="mx-auto max-w-2xl text-center">
+			<p class="mb-5 text-sm font-semibold uppercase tracking-[0.35em] text-teal-300">
+				<span id="not-found-status">Error 404</span>
+			</p>
+			<h1 class="text-balance text-4xl font-bold tracking-tight text-slate-100 sm:text-5xl">
+				Página no encontrada
+			</h1>
+			<p class="mx-auto mt-6 max-w-xl text-pretty text-base leading-7 text-slate-400 sm:text-lg">
+				El enlace puede haber cambiado o la ruta ya no está disponible. Vuelve al inicio
+				o revisa el archivo de proyectos para continuar explorando mi trabajo.
+			</p>
+
+			<div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+				<a
+					href="/"
+					class="inline-flex w-full items-center justify-center border-b border-teal-300 pb-1 text-sm font-semibold text-slate-100 transition hover:text-teal-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-teal-300 sm:w-auto"
+				>
+					Volver al inicio
+				</a>
+				<a
+					href="/archivo"
+					class="inline-flex w-full items-center justify-center border-b border-slate-700 pb-1 text-sm font-semibold text-slate-400 transition hover:border-teal-300 hover:text-teal-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-teal-300 sm:w-auto"
+				>
+					Ver proyectos
+				</a>
+			</div>
+		</div>
+	</section>
+
+	<script>
+		import { slotText } from "slot-text";
+
+		const status = document.querySelector("#not-found-status");
+
+		if (status instanceof HTMLElement) {
+			const label = slotText(status, "Error 404", {
+				direction: "up",
+				duration: 360,
+				stagger: 35,
+			});
+
+			window.setTimeout(() => {
+				label.set("Ruta perdida", { direction: "down" });
+			}, 900);
+		}
+	</script>
+</Layout>


### PR DESCRIPTION
Closes #2

## Summary
- Add a custom Astro 404 page aligned with the portfolio visual system.
- Use slot-text for a subtle animated status label.
- Include portfolio content/UI refinements from this branch: EPAM role timeline, updated education/title copy, EPAM links, and restored profile image flip.

## Changes
| File | Change |
|------|--------|
| `src/pages/404.astro` | New responsive 404 page with minimal CTAs and slot-text animation |
| `package.json` / `pnpm-lock.yaml` | Add slot-text dependency |
| `src/data.json` | Update EPAM role, timeline, skills, education title, and EPAM link |
| `src/components/CardWork.astro` | Render optional experience timeline |
| `src/components/Description.astro` | Update current role and EPAM URL |
| `src/components/header/PersonalImage.astro` | Keep flip interaction with corrected age |
| `src/layouts/Layout.astro` | Update SEO description |

## Test Plan
- [x] Node 24 selected with the project `.nvmrc`
- [x] Production build completed successfully
- [x] Astro check reports 0 errors, 0 warnings, 0 hints

## Notes
- No local dev server was started for this change.
- Vercel Preview Deployment should be used for visual validation before merge.
- No extra Vercel configuration is expected for the 404 route; Astro provides it through `src/pages/404.astro`.
