### PR TITLE
fix(ui): polish portfolio labels

### DIFF
--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -9,11 +9,9 @@ import ViewFullResume from "./ViewFullResume.astro";
 	aria-label="Experiencia"
 >
 	<div
-		class="sticky top-0 z-20 -mx-6 mb-4 w-screen bg-slate-900/75 px-6 py-5 backdrop-blur md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
+		class="sticky top-0 z-20 -mx-6 mb-4 w-screen bg-slate-900/75 px-6 py-5 backdrop-blur md:-mx-12 md:px-12 lg:relative lg:top-auto lg:mx-auto lg:w-full lg:bg-transparent lg:px-0 lg:py-0 lg:backdrop-blur-none"
 	>
-		<h2
-			class="text-sm font-bold uppercase tracking-widest text-slate-200 lg:sr-only"
-		>
+		<h2 class="text-sm font-bold uppercase tracking-widest text-slate-200">
 			Experiencia
 		</h2>
 	</div>

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -21,16 +21,16 @@ import ProjectList from "./ProjectsList.astro";
 		<div class="mt-12">
 			<a
 				class="inline-flex items-center font-medium leading-tight text-slate-200 group"
-				aria-label="View Full Project Archive"
+				aria-label="Ver archivo completo de proyectos"
 				href="/archivo"
 				><span
 					><span
 						class="border-b border-transparent pb-px transition group-hover:border-teal-300 motion-reduce:transition-none"
-						>Ver lista de proyectos<!-- -->
+						>Ver archivo de <!-- -->
 					</span><span class="whitespace-nowrap"
 						><span
 							class="border-b border-transparent pb-px transition group-hover:border-teal-300 motion-reduce:transition-none"
-							>Completos</span
+							>proyectos</span
 						><svg
 							xmlns="http://www.w3.org/2000/svg"
 							viewBox="0 0 20 20"

--- a/src/components/ViewFullResume.astro
+++ b/src/components/ViewFullResume.astro
@@ -1,12 +1,12 @@
 <div class="mt-12">
 	<a
-		class="inline-flex items-center font-medium leading-tight text-slate-200 font-semibol group"
-		aria-label="Ver el CV completo"
+		class="inline-flex items-center font-medium leading-tight text-slate-200 font-semibold group"
+		aria-label="Ver CV completo"
 		href="/cv.pdf"
 		><span
 			><span
 				class="border-b border-transparent pb-px transition group-hover:border-teal-300 motion-reduce:transition-none"
-				>Ver el<!-- -->
+				>Ver <!-- -->
 			</span><span class="whitespace-nowrap"
 				><span
 					class="border-b border-transparent pb-px transition group-hover:border-teal-300 motion-reduce:transition-none"

--- a/src/data.json
+++ b/src/data.json
@@ -102,16 +102,16 @@
       "description": "Parte del equipo de arquitectura e infraestructura cloud para el sector bancario regional, implementando soluciones multinube en AWS y Azure. Enfocado en diseño de arquitectura, gobierno cloud, seguridad, automatización de infraestructura, pipelines y optimización de recursos.",
       "timeline": [
         {
-          "from": "Oct 2024",
-          "to": "Ago 2025",
-          "role": "Cloud Engineer",
-          "description": "Automatización de infraestructura, CI/CD, módulos cloud y operación segura en entornos AWS y Azure."
-        },
-        {
           "from": "Sep 2025",
           "to": "Presente",
           "role": "Cloud Architect",
           "description": "Diseño de arquitectura cloud, gobierno, seguridad y evolución de soluciones multinube para banca regional."
+        },
+        {
+          "from": "Oct 2024",
+          "to": "Ago 2025",
+          "role": "Cloud Engineer",
+          "description": "Automatización de infraestructura, CI/CD, módulos cloud y operación segura en entornos AWS y Azure."
         }
       ],
       "tech": [


### PR DESCRIPTION
Closes #7

## Summary
- Polish CV and project archive CTA copy so labels do not visually concatenate.
- Reorder the EPAM timeline so the current Cloud Architect role appears first.
- Make the Experience heading visible consistently and fix a Tailwind font-weight typo.

## Changes
| File | Change |
|------|--------|
| `src/components/ViewFullResume.astro` | Update CV CTA text and fix `font-semibold` class |
| `src/components/Projects.astro` | Update project archive CTA copy and Spanish aria label |
| `src/components/Experience.astro` | Keep `Experiencia` heading visible across breakpoints |
| `src/data.json` | Reorder EPAM timeline entries |

## Test Plan
- [x] Node 24 selected with the project `.nvmrc`
- [x] Production build completed successfully
- [x] Astro check reports 0 errors, 0 warnings, 0 hints

## Notes
- No local dev server was started for this change.
